### PR TITLE
An import was referencing a directory using a capitalized name

### DIFF
--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -13,7 +13,7 @@
 @import "../js/components/queryBuilder/queryOverview/_queryOverview";
 
 // Query Overview Control
-@import "../js/components/queryBuilder/queryOverview/QueryOverviewControl/_queryOverviewControl";
+@import "../js/components/queryBuilder/queryOverview/queryOverviewControl/_queryOverviewControl";
 
 // Query Set
 @import "../js/components/queryBuilder/querySets/_querySet";


### PR DESCRIPTION
However, the directory actually started with a lowercase letter. This was breaking the import and thus breaking the build. This simple commit fixes that import allowing the build to work correctly.

I have tested this by running `npm run build`. After doing so gulp ran successfully and there was a `build/` directory created containing everything I would expect to be there.