### PR TITLE
[Do not merge] gulp: build CNAME for GH Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+cognoma.org

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -3,7 +3,6 @@ import gulp   from 'gulp';
 import del    from 'del';
 
 gulp.task('clean', function() {
-
+  del([config.buildDir + 'CNAME']);
   return del([config.buildDir]);
-  
 });

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -12,3 +12,8 @@
 global.isProd = false;
 
 require('./gulp');
+
+// Copy CNAME to build for GitHub Pages
+var gulp = require('gulp');
+gulp.src(['./CNAME'])
+  .pipe(gulp.dest('./build'));


### PR DESCRIPTION
This is my attempt to create a `CNAME` file in the `build` directory to configure GitHub Pages (see 
https://github.com/cognoma/frontend/issues/74).

Unfortunately, it only works every other run of `npm run build`. The failures occur due to:

```
[15:50:30] Requiring external module babel-register
[15:50:31] Using gulpfile ~/Documents/greene/cognoma/frontend/gulpfile.babel.js
[15:50:31] Starting 'clean'...
[15:50:31] 'clean' errored after 14 ms
[15:50:31] Error: ENOTEMPTY: directory not empty, rmdir '/home/dhimmel/Documents/greene/cognoma/frontend/build'
```

@bdolly hopefully you can handle this (or know of a better way to build `CNAME`)