### PR TITLE
creates gulp copyCNAME file task

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+cognoma.org

--- a/gulp/tasks/copyCNAME.js
+++ b/gulp/tasks/copyCNAME.js
@@ -1,0 +1,14 @@
+import gulp        from 'gulp';
+import runSequence from 'run-sequence';
+
+gulp.task('copyCNAME', function(cb) {
+
+  cb = cb || function() {};
+
+  global.isProd = true;
+
+  // copies the CNAME file to the build directory 
+  // for use with github pages
+  gulp.src(['./CNAME']).pipe(gulp.dest('./build'));
+
+});

--- a/gulp/tasks/development.js
+++ b/gulp/tasks/development.js
@@ -5,6 +5,6 @@ gulp.task('dev', ['clean'], function(cb) {
 
   global.isProd = false;
 
-  runSequence(['styles', 'images', 'fonts','views'], 'browserify', 'watch', cb);
+  runSequence(['styles', 'images', 'fonts','views','copyCNAME'], 'browserify', 'watch', cb);
 
 });

--- a/gulp/tasks/production.js
+++ b/gulp/tasks/production.js
@@ -7,6 +7,6 @@ gulp.task('prod', ['clean'], function(cb) {
 
   global.isProd = true;
 
-  runSequence(['styles', 'images', 'fonts', 'views'], 'browserify', 'gzip', cb);
+  runSequence(['styles', 'images', 'fonts', 'views','copyCNAME'], 'browserify', 'gzip', cb);
 
 });


### PR DESCRIPTION
copies the CNAME file from the project root to the `/build` directory for use with GH pages