### PR TITLE
logs node env var for testing

### DIFF
--- a/gulp/tasks/unit.js
+++ b/gulp/tasks/unit.js
@@ -9,6 +9,8 @@ import browserSync from 'browser-sync';
 
 let _TEST_SERVER, _TEST_REPORT;
 const isCI = process.env.CI && Boolean(process.env.CI_PULL_REQUEST);
+console.log(`isCI: ${isCI}`);
+console.log(process.env);
 
 // fire up an instance of browserSync to show the Karma HTML Reports
 // and live reload them as we code


### PR DESCRIPTION
testing the node env var in Circle CI in order to kill skip the browsersync process that's causing tests to timeout