### PR TITLE
WIP Select-All Button for Diseases

### DIFF
--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -19,14 +19,14 @@ const QueryBuilderComponent = {
                  'QueryBuilderService',
                  '$log',
                  function(
-                    $scope, 
-                    $rootScope, 
-                    _, 
-                    DiseaseModel, 
+                    $scope,
+                    $rootScope,
+                    _,
+                    DiseaseModel,
                     $state,
-                    $timeout, 
-                    MutationsService, 
-                    DiseaseService, 
+                    $timeout,
+                    MutationsService,
+                    DiseaseService,
                     ProgressIndicatorBarService,
                     QueryBuilderService,
                     $log,
@@ -35,8 +35,8 @@ const QueryBuilderComponent = {
             	     'ngInject';
 
                    let vm = this;
-                  
-                    
+
+
 
                    $log = $log.getInstance('QueryBuilderComponent', false);
                    $log.log('');
@@ -44,66 +44,66 @@ const QueryBuilderComponent = {
                    const progressStateName = vm.currentState() == 'mutations' ? 'genes' : 'samples';
 
                    vm.$onInit = ()=>{
-                      
-                        
-                        // get the progress bar controller 
+
+
+                        // get the progress bar controller
                         // and attach it to the local scope
                         ProgressIndicatorBarService
                             .get('queryBuilderProgress')
-                            .then(progressBarInstance=>{ 
+                            .then(progressBarInstance=>{
                               vm.progressBar = progressBarInstance;
                               vm.progressBar.goTo(`Search ${progressStateName}`);
                             });
 
-                        
+
 
                    }
 
-                   
 
-                    
+
+
 
                     /* =======================================================================
-                      Progress Indicator Bar 
+                      Progress Indicator Bar
                     ========================================================================== */
 
-                   // define the steps for the query builder 
+                   // define the steps for the query builder
                         vm.progressIndicators = [
                             {
-                              title:  'Search Genes',  
-                              state:  'app.queryBuilder.mutations' , 
-                              icon:   '', 
+                              title:  'Search Genes',
+                              state:  'app.queryBuilder.mutations' ,
+                              icon:   '',
                               active: true,
                               type:   'icon'
                             },
                             {
-                              title:  'Add Genes',     
-                              state:  'app.queryBuilder.mutations' , 
-                              icon:   '', 
+                              title:  'Add Genes',
+                              state:  'app.queryBuilder.mutations' ,
+                              icon:   '',
                               active: false,
                               type:   'icon'
                             },
                             {
                               title:  'Search Samples',
-                              state:  'app.queryBuilder.disease' ,   
-                              icon:   '', 
+                              state:  'app.queryBuilder.disease' ,
+                              icon:   '',
                               active: false,
                               type:   'icon'
                             },
                             {
-                              title:  'Add Samples',  
-                              state:  'app.queryBuilder.disease' ,   
-                              icon:   '', 
+                              title:  'Add Samples',
+                              state:  'app.queryBuilder.disease' ,
+                              icon:   '',
                               active: false ,
                               type:   'icon'
                             }
                         ];
 
-                        // define the 'Review Query' button to be added  
+                        // define the 'Review Query' button to be added
                         let indicatorButton = {
-                             title:  'Submit Query',  
-                             // state:  'app.queryBuilder.review' ,   
-                             icon:   '', 
+                             title:  'Submit Query',
+                             // state:  'app.queryBuilder.review' ,
+                             icon:   '',
                              active: false,
                              type:   'button',
                              action:($event)=>{
@@ -113,63 +113,68 @@ const QueryBuilderComponent = {
                          };
 
 
-                    
 
-                   
+
+
                     /**
-                     * Add the "Review Query" Button to the Progress Bar 
-                     * if it's not already added 
+                     * Add the "Review Query" Button to the Progress Bar
+                     * if it's not already added
                      */
                     let _showIndicatorButton = () =>{
                       let indicatorButtonAdded = _.findWhere(vm.progressIndicators, {title: indicatorButton.title}) != undefined;
                       if((vm.mutationsSet.length && vm.diseaseSet.length) && !indicatorButtonAdded){
                         vm.progressIndicators.push(indicatorButton);
                         vm.progressBar.goTo(indicatorButton, false);
-                      } 
+                      }
                     }
 
 
 
 
                     /**
-                     * Remove the "Review Query" button from the progress bar 
+                     * Remove the "Review Query" button from the progress bar
                      */
                     let _removeIndicatorButton = ()=>{
-                      
+
                        let indicatorButtonIndex =  _.findIndex(vm.progressIndicators,  indicatorButton);
 
                        if((!vm.mutationsSet.length || !vm.diseaseSet.length) && indicatorButtonIndex >= 0 ){
                         vm.progressIndicators = [
                           ...vm.progressIndicators.slice(0, indicatorButtonIndex)
                         ];
-                       } 
+                       }
                     };
-                    
 
-                   
+
+
 
                    /* =======================================================================
                       querySets: list operations
                     ========================================================================== */
 
                   /**
-                   * @param  {String} setType - type of query set to manipulate 
-                   * 
+                   * @param  {String} setType - type of query set to manipulate
+                   *
                    * @return {Void}
                    */
                     vm.clearSet =setType=>{
-                        
+
                         _removeIndicatorButton();
                         return vm[`${setType.setType}Set`] = [];
                     }
 
-                  
+                    vm.selelectAll =setType=>{
+
+                        return vm[`${setType.setType}Set`] = ['GBM'];
+                    }
+
+
                   /**
                    * Checks if set has been sorted by given params
                    * @param  {Array}
                    * @param  {Array}
                    * @param  {String}
-                   * 
+                   *
                    * @return {Boolean}
                    */
                   let _setIsSorted = (list, sortedList, sortedOn)=>{
@@ -179,17 +184,17 @@ const QueryBuilderComponent = {
                               );
                   };
 
-                  
+
                   /**
                    * Sort a set given property
-                   * if set is already sorted returns a reversed sorted set 
-                   * if is NOT already sorted returns a sorted set 
-                   * 
-                   * @param  {Object} sortParams 
+                   * if set is already sorted returns a reversed sorted set
+                   * if is NOT already sorted returns a sorted set
+                   *
+                   * @param  {Object} sortParams
                    *             |- {String} set - type of query set to manipulate
-                   *             |- {String} sortOn - the property to sort the array by 
-                   *             
-                   * @return {Array} - array of objects sorted by specified property  
+                   *             |- {String} sortOn - the property to sort the array by
+                   *
+                   * @return {Array} - array of objects sorted by specified property
                    */
                   vm.sortSetOn = (sortParams)=>{
 
@@ -200,13 +205,13 @@ const QueryBuilderComponent = {
                     vm[`${sortParams.set}Set`] = (_setIsSorted(list, sortedList, sortOn) ? list.reverse() : sortedList);
                     return (_setIsSorted(list, sortedList, sortOn) ? list.reverse() : sortedList);
                   };
-            
-                  
+
+
 
 
                 /**
-                 * @param  {Object} queryParam - mutation or DiseaseModel   
-                 * @return {Array | false} Array of objects if queryParam is added, 
+                 * @param  {Object} queryParam - mutation or DiseaseModel
+                 * @return {Array | false} Array of objects if queryParam is added,
                  *                         false if it already exists in set
                  */
                 vm.addParamToQuery = queryParamData=>{
@@ -237,21 +242,21 @@ const QueryBuilderComponent = {
 
                 /**
                  * @param  {Object} paramData
-                 *              | - {String} paramType - type of query set to manipulate 
-                 *              | - {String | Number} id - specific identifier for item to remove from query set 
-                 *              | - {String} paramRef - property of object to search the query set by, should be the property type of the id 
-                 *              
-                 * @return {Array} - return the new array for testing 
+                 *              | - {String} paramType - type of query set to manipulate
+                 *              | - {String | Number} id - specific identifier for item to remove from query set
+                 *              | - {String} paramRef - property of object to search the query set by, should be the property type of the id
+                 *
+                 * @return {Array} - return the new array for testing
                  */
                 vm.removeParamFromQuery = (paramData)=>{
-                    $log.log(`removeParamFromQuery:${paramData.paramType} - ${paramData.id} ref by ${paramData.paramRef}`); 
+                    $log.log(`removeParamFromQuery:${paramData.paramType} - ${paramData.id} ref by ${paramData.paramRef}`);
                     let currentSet = _.assign([],vm[`${paramData.paramType}Set`]);
 
                     let setIndex = _.indexOf(_.pluck(currentSet, paramData.paramRef), paramData.id);
                     $log.log(`removeParamFromQuery:setIndex:${setIndex}`);
 
                     currentSet = [
-                      ...currentSet.slice(0, setIndex), 
+                      ...currentSet.slice(0, setIndex),
                       ...currentSet.slice(setIndex + 1)
                     ];
 
@@ -268,12 +273,12 @@ const QueryBuilderComponent = {
 
 
 
-    
+
                 /**
-                 * Update the positives and negatives count for each disease listing 
+                 * Update the positives and negatives count for each disease listing
                  * using the DiseaseModel to calculate a new set of aggregate values
                  * based on the current user selected query param. sets
-                 * 
+                 *
                  * @return {Void}
                  */
                 vm._updateDiseaseListingsCounts = ()=>{
@@ -290,17 +295,17 @@ const QueryBuilderComponent = {
                                 .then(function() {
                                     diseaseModel.mutationsLoading = false;
                                 });
-                        
+
                         });//END vm.diseaseSet.map
 
                     }//end if
-                    
+
                 }//_updateDiseaseListingsCounts
 
 
 
 
-                
+
             }]
 }
 

--- a/app/js/components/queryBuilder/queryParamSelector/diseaseTypeInstructions/diseaseType_instructions.tpl.html
+++ b/app/js/components/queryBuilder/queryParamSelector/diseaseTypeInstructions/diseaseType_instructions.tpl.html
@@ -8,9 +8,9 @@
 					<h2><b>Searching for Samples by Disease Type</b></h2>
 				</li>
 				<li>
-					<h2><b>Selecting Samples by Disease Type to add to your Disease Type Set by Clicking</b></h2>
+					<h2><b>Selecting Samples by Disease Type to add to your Disease Type Set by Clicking or Selecting all Samples from All Diseases by Clicking the "Select All" Button</b></h2>
 				</li>
 			</ol>
 		</div>
-		
+
 	</section>

--- a/app/js/components/queryBuilder/queryParamSelector/mutationsInstructions/mutations_instructions.tpl.html
+++ b/app/js/components/queryBuilder/queryParamSelector/mutationsInstructions/mutations_instructions.tpl.html
@@ -13,15 +13,15 @@
 						<small>
 							The genes in your <strong>Gene Set</strong> will compose the Y vector that is used to determine gene or pathway inactivation. The hypothesis assumption is that a mutation in any gene in your Gene Set will cause a measurable change in downstream gene expression that can be detected by the algorithm you build.
 						</small>
-					</blockquote>	
+					</blockquote>
 				</li>
 				<li>
 					<h2><b>Searching for Samples by Disease Type</b></h2>
 				</li>
 				<li>
-					<h2><b>Selecting Disease Types to add to your Disease Types Set by Clicking</b></h2>
+					<h2><b>Selecting Disease Types to add to your Disease Types Set by Clicking or Selecting all Samples from All Diseases by Clicking the "Select All" Button</b></h2>
 				</li>
 			</ol>
 		</div>
-		
+
 	</section>

--- a/app/js/components/queryBuilder/querySets/querySetDiseaseType/_querySetDiseaseType.scss
+++ b/app/js/components/queryBuilder/querySets/querySetDiseaseType/_querySetDiseaseType.scss
@@ -12,6 +12,10 @@
 .disease-clear-button{
   margin-left: -2.5rem;
 }
+.disease-selectall-button{
+  color: green;
+
+}
 .disease-card-display{
   .disease-card-body{padding:0;}
   .disease-card-title{font-size:14px;}

--- a/app/js/components/queryBuilder/querySets/querySetDiseaseType/querySetDiseaseType.component.js
+++ b/app/js/components/queryBuilder/querySets/querySetDiseaseType/querySetDiseaseType.component.js
@@ -5,7 +5,8 @@ const QuerySetDiseaseTypeComponent = {
     bindings: {
       'diseaseSet':  '<',
       'clearSet':     '&',
-      'sortSet':      '&'
+      'sortSet':      '&',
+      'selectAll': '&'
     },
     controller:['$rootScope','_','$log', function ($rootScope,_, $log) {
           'ngInject';
@@ -13,7 +14,7 @@ const QuerySetDiseaseTypeComponent = {
           $log.log('');
 
           let vm = this;
-          
+
           vm.samplesTotal = ()=>{
             let samplesFlattened = _.pluck(this.diseaseSet, 'samples').map(samples=>{
               return (typeof samples  == 'number' ? samples : samples.length);

--- a/app/js/components/queryBuilder/querySets/querySetDiseaseType/querySetDiseaseType.tpl.html
+++ b/app/js/components/queryBuilder/querySets/querySetDiseaseType/querySetDiseaseType.tpl.html
@@ -19,6 +19,13 @@
   </div>
 </div>
 
+</div>
+<div class="col-xs-2">
+  <button class="label selectall-button disease-selectall-button"
+        ng-click="$ctrl.selectAll({setType:'disease'})">SELECT ALL</button>
+</div>
+</div>
+
 <div class="col-xs-12 sample-set-bar">
   <span>SAMPLES {{ $ctrl.samplesTotal() }}</span>
   <span>POSITIVES


### PR DESCRIPTION
Closes #99.

Adds a "Select All" button to allow a user to easily include all diseases (and all samples) in a query without manually selecting all the diseases.

There seem to be a couple of places where this button could go; I thought placing it under disease type set (see screen shot below) made the most sense but I'm open to suggestions.

![image](https://user-images.githubusercontent.com/25244432/31588335-5e85d510-b1be-11e7-9425-2b24a10cf0d0.png)

This is still WIP. I need to revise lines 166-169 in `queryBuilderComponents.js` to create a working function to add all the diseases to the query.
