### PR TITLE
Feature/clear all added button

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -20,5 +20,16 @@
     <ui-view></ui-view>    
    
     <script src="js/main.js"></script>
+    <!-- Google Analytics -->
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-20583020-12', 'auto');
+    ga('send', 'pageview');
+    </script>
+    <!-- End Google Analytics -->
   </body>
 </html>

--- a/app/js/components/common/cgTable/cgTable.component.js
+++ b/app/js/components/common/cgTable/cgTable.component.js
@@ -75,6 +75,13 @@ const cgTable = {
       $scope.$on("SEARCH_QUERY_CHANGED", () => {
         _deselectAllResults();
       });
+
+      /**
+       * Listens for REMOVED_PARAMS_FROM_QUERY event broadcast in queryParamSelector.component.js
+       */
+      $scope.$on("REMOVED_PARAMS_FROM_QUERY", () => {
+        _deselectAllResults();
+      });
     }
   ]
 };

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -113,7 +113,7 @@ const QueryBuilderComponent = {
 
         vm._updateDiseaseListingsCounts();
 
-        return vm[`${vm.currentState()}Set`];
+        return addedParams;
       };
 
       /**
@@ -125,29 +125,21 @@ const QueryBuilderComponent = {
        * @return {Array} - return the new array for testing
        */
       vm.removeParamFromQuery = selectedParams => {
-        /*$log.log(
-          `removeParamFromQuery:${paramData.paramType} - ${
-            paramData.id
-          } ref by ${paramData.paramRef}`
-        );
-        let currentSet = _.assign([], vm[`${paramData.paramType}Set`]);
+        const addedParams = vm[`${vm.currentState()}Set`],
+          comparator = vm.currentState() == "mutations" ? "_id" : "acronym";
 
-        let setIndex = _.indexOf(
-          _.pluck(currentSet, paramData.paramRef),
-          paramData.id
-        );
-        $log.log(`removeParamFromQuery:setIndex:${setIndex}`);
+        selectedParams.forEach(param => {
+          addedParams.splice(
+            _.indexOf(
+              addedParams,
+              _.findWhere(addedParams, { comparator: param[comparator] })
+            )
+          );
 
-        currentSet = [
-          ...currentSet.slice(0, setIndex),
-          ...currentSet.slice(setIndex + 1)
-        ];
+          $log.log(`removeParamFromQuery: ${param.comparator}`);
+        });
 
-        vm[`${paramData.paramType}Set`] = currentSet;
-
-        vm._updateDiseaseListingsCounts();*/
-
-        return vm[`${paramData.paramType}Set`];
+        return addedParams;
       };
 
       /**

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -72,7 +72,7 @@ const QueryBuilderComponent = {
        * @param  {Array} selectedParams - Array of mutations or DiseaseModels to be removed
        * @return {Array} - return array of added param objects
        */
-      vm.removeParamFromQuery = selectedParams => {
+      vm.removeParamsFromQuery = selectedParams => {
         const addedParams = vm[`${vm.currentState()}Set`],
           comparator = vm.currentState() == "mutations" ? "_id" : "acronym";
 

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -64,7 +64,6 @@ const QueryBuilderComponent = {
         });
 
         vm._updateDiseaseListingsCounts();
-
         return addedParams;
       };
 

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -70,7 +70,6 @@ const QueryBuilderComponent = {
 
       /**
        * @param  {Array} selectedParams - Array of mutations or DiseaseModels to be removed
-       *
        * @return {Array} - return array of added param objects
        */
       vm.removeParamFromQuery = selectedParams => {

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -124,8 +124,8 @@ const QueryBuilderComponent = {
        *
        * @return {Array} - return the new array for testing
        */
-      vm.removeParamFromQuery = paramData => {
-        $log.log(
+      vm.removeParamFromQuery = selectedParams => {
+        /*$log.log(
           `removeParamFromQuery:${paramData.paramType} - ${
             paramData.id
           } ref by ${paramData.paramRef}`
@@ -145,7 +145,7 @@ const QueryBuilderComponent = {
 
         vm[`${paramData.paramType}Set`] = currentSet;
 
-        vm._updateDiseaseListingsCounts();
+        vm._updateDiseaseListingsCounts();*/
 
         return vm[`${paramData.paramType}Set`];
       };

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -39,56 +39,8 @@ const QueryBuilderComponent = {
         vm.currentState() == "mutations" ? "genes" : "samples";
 
       /* =======================================================================
-                      querySets: list operations
-                    ========================================================================== */
-
-      /**
-       * @param  {String} setType - type of query set to manipulate
-       *
-       * @return {Void}
-       */
-      vm.clearSet = setType => {
-        return (vm[`${setType.setType}Set`] = []);
-      };
-
-      /**
-       * Checks if set has been sorted by given params
-       * @param  {Array}
-       * @param  {Array}
-       * @param  {String}
-       *
-       * @return {Boolean}
-       */
-      let _setIsSorted = (list, sortedList, sortedOn) => {
-        return _.isEqual(
-          _.pluck(list, sortedOn),
-          _.pluck(sortedList, sortedOn)
-        );
-      };
-
-      /**
-       * Sort a set given property
-       * if set is already sorted returns a reversed sorted set
-       * if is NOT already sorted returns a sorted set
-       *
-       * @param  {Object} sortParams
-       *             |- {String} set - type of query set to manipulate
-       *             |- {String} sortOn - the property to sort the array by
-       *
-       * @return {Array} - array of objects sorted by specified property
-       */
-      vm.sortSetOn = sortParams => {
-        let list = _.assign([], vm[`${sortParams.set}Set`]);
-        let sortOn = sortParams.sortOn;
-        let sortedList = _.sortBy(list, sortOn);
-
-        vm[`${sortParams.set}Set`] = _setIsSorted(list, sortedList, sortOn)
-          ? list.reverse()
-          : sortedList;
-        return _setIsSorted(list, sortedList, sortOn)
-          ? list.reverse()
-          : sortedList;
-      };
+        querySets: list operations
+      ========================================================================== */
 
       /**
        * @param  {Array} selectedParams - Array of mutations or DiseaseModels to be added
@@ -117,12 +69,9 @@ const QueryBuilderComponent = {
       };
 
       /**
-       * @param  {Object} paramData
-       *              | - {String} paramType - type of query set to manipulate
-       *              | - {String | Number} id - specific identifier for item to remove from query set
-       *              | - {String} paramRef - property of object to search the query set by, should be the property type of the id
+       * @param  {Array} selectedParams - Array of mutations or DiseaseModels to be removed
        *
-       * @return {Array} - return the new array for testing
+       * @return {Array} - return array of added param objects
        */
       vm.removeParamFromQuery = selectedParams => {
         const addedParams = vm[`${vm.currentState()}Set`],
@@ -138,6 +87,8 @@ const QueryBuilderComponent = {
 
           $log.log(`removeParamFromQuery: ${param.comparator}`);
         });
+
+        vm._updateDiseaseListingsCounts();
 
         return addedParams;
       };

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -90,6 +90,8 @@ const QueryBuilderComponent = {
 
         vm._updateDiseaseListingsCounts();
 
+        $scope.$broadcast("REMOVED_PARAMS_FROM_QUERY");
+
         return addedParams;
       };
 

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -81,8 +81,9 @@ const QueryBuilderComponent = {
           addedParams.splice(
             _.indexOf(
               addedParams,
-              _.findWhere(addedParams, { comparator: param[comparator] })
-            )
+              _.findWhere(addedParams, { [comparator]: param[comparator] })
+            ),
+            1
           );
 
           $log.log(`removeParamFromQuery: ${param.comparator}`);

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -91,27 +91,27 @@ const QueryBuilderComponent = {
       };
 
       /**
-       * @param  {Array} queryParamData - Array of mutations or DiseaseModels
+       * @param  {Array} selectedParams - Array of mutations or DiseaseModels to be added
        * @return {Array | false} Array of objects if queryParam is added,
        *                         false if it already exists in set
        */
-      vm.addParamToQuery = queryParamData => {
-        let paramSet = _.assign([], vm[`${vm.currentState()}Set`]),
-          allParams = [];
+      vm.addParamsToQuery = selectedParams => {
+        const addedParams = vm[`${vm.currentState()}Set`],
+          comparator = vm.currentState() == "mutations" ? "_id" : "acronym";
 
-        queryParamData.forEach(queryParam => {
-          let queryParamInSet = _.findWhere(paramSet, queryParam);
+        const filteredSelectedParams = selectedParams.filter(
+          selectedParam =>
+            !addedParams.find(
+              addedParam => addedParam[comparator] === selectedParam[comparator]
+            )
+        );
 
-          $log.log(`:${vm.currentState()}Set`);
-
-          if (queryParamInSet == undefined && queryParam.isSelected) {
-            paramSet.push(queryParam);
-            vm[`${vm.currentState()}Set`] = paramSet;
-
-            vm._updateDiseaseListingsCounts();
-            queryParam.isSelected = false;
-          }
+        filteredSelectedParams.forEach(param => {
+          addedParams.push(param);
+          param.isSelected = false;
         });
+
+        vm._updateDiseaseListingsCounts();
 
         return vm[`${vm.currentState()}Set`];
       };

--- a/app/js/components/queryBuilder/queryOverview/queryOverview.component.js
+++ b/app/js/components/queryBuilder/queryOverview/queryOverview.component.js
@@ -3,7 +3,7 @@ const template = require("./queryOverview.tpl.html");
 const QueryOverviewComponent = {
     template,
     bindings: {
-        removeParam: "&",
+        removeParam: "<",
         mutationsSet: "<",
         diseaseSet: "<",
         user: "="

--- a/app/js/components/queryBuilder/queryOverview/queryOverview.tpl.html
+++ b/app/js/components/queryBuilder/queryOverview/queryOverview.tpl.html
@@ -15,7 +15,7 @@
   desc="classify samples by their mutation status in selected genes"
   list-type="mutations"
   param-list="$ctrl.mutationsSet"
-  remove-param="$ctrl.removeParam({id, paramRef, paramType})"
+  remove-param="$ctrl.removeParam"
 >
 </query-overview-control>
 
@@ -24,6 +24,6 @@
   desc="Select Samples to Include in Query by Disease Type"
   list-type="disease"
   param-list="$ctrl.diseaseSet"
-  remove-param="$ctrl.removeParam({id, paramRef, paramType})"
+  remove-param="$ctrl.removeParam"
   >
 </query-overview-control >

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/_queryOverviewControl.scss
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/_queryOverviewControl.scss
@@ -1,18 +1,22 @@
-.query-overview--control {
+.query-overview-control {
+  align-items: normal;
   display: block;
   width: 100%;
-  min-height: 200px;
-  padding-bottom: 20px;
+  padding: 20px;
   color: $white;
+  font-size: 20px;
   text-align: left;
+  border-left: 5px solid transparent;
 
-  &.active {
+  &:hover {
+    background: rgba($black, 0.15);
+  }
+
+  &--active {
     background: rgba($black, 0.25);
-    border-top: none;
-    border-right: none;
-    border-bottom: none;
     border-left: 5px solid $green;
-    .query-overview--control-title {
+
+    .query-overview-control__title {
       color: $green;
     }
   }
@@ -36,22 +40,21 @@
   }
 }
 
-.query-overview--control-title {
+&__title {
   position: relative;
-  padding: 17px 0 17px 17px;
-  margin: 0;
+  margin: 5px 0;
   text-transform: uppercase;
   &:hover {
     cursor: pointer;
   }
 }
-.query-overview--control-count {
+&__count {
   display: inline-block;
   color: $white;
   transform: translateY(-2px);
 }
 
-.query-overview--control-param {
+&__param {
   position: relative;
   padding: 3px 5px;
   margin: 5px 0;
@@ -65,19 +68,19 @@
     box-shadow: 0 0 5px 0 rgba($black, 0.5);
     cursor: pointer;
 
-    .query-overview--control__remove {
+    .query-overview-control__remove {
       right: -19px;
       opacity: 1;
     }
   }
 }
-.query-overview--control-param-title {
+&__param-title {
   font-weight: bold;
   text-transform: uppercase;
 }
 
 
-.query-overview--control-param-add {
+&__param-add {
   height: 25px;
   padding: 0;
   margin: 5px 0 5px 15px;
@@ -102,7 +105,7 @@
 .disease-listing {
   transition: 1s all ease;
 
-  .query-overview--control-param-title {
+  .query-overview-control-param-title {
     font-size: 12px;
   }
   .control-param-summary {

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/diseaseListing/diseaseListing.component.js
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/diseaseListing/diseaseListing.component.js
@@ -1,31 +1,26 @@
-const template = require('./diseaseListing.tpl.html');
+const template = require("./diseaseListing.tpl.html");
 
 const diseaseListingComponent = {
     template,
     bindings: {
-        'name':          '@',
-        'positives':     '=',
-        'negatives':     '=',
-        'samples':       '=',
-        'isLoading':     '<',
-        'onRemoveParam': '&'
+        disease: "=",
+        onRemoveParam: "<"
     },
-    controller: ['$rootScope','$log',function ($rootScope, $log) {
-            'ngInject';
-            $log = $log.getInstance('diseaseListingComponent', true);
+    controller: [
+        "$rootScope",
+        "$log",
+        function($rootScope, $log) {
+            "ngInject";
+            $log = $log.getInstance("diseaseListingComponent", true);
 
-            this.$onInit = ()=>{
-                $log.log(`${this.name}:`);    
-            }
-
-            
-
-            
-
-        }]
-}
+            this.$onInit = () => {
+                $log.log(`${this.name}:`);
+            };
+        }
+    ]
+};
 
 export default {
-	name: 'diseaseListing',
-	obj: diseaseListingComponent
+    name: "diseaseListing",
+    obj: diseaseListingComponent
 };

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/diseaseListing/diseaseListing.tpl.html
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/diseaseListing/diseaseListing.tpl.html
@@ -3,26 +3,26 @@
 	ng-class="{'data-loading': $ctrl.isLoading}"
 >
 
-  	<span class="query-overview--control-param-title js-test-name">{{$ctrl.name}}</span>
+  	<span class="query-overview--control-param-title js-test-name">{{$ctrl.disease.name}}</span>
 
   	<summary class="control-param-summary">
-  		<p class="sample-count">SAMPLES <strong class="js-test-sampleCount"> {{$ctrl.samples.length}}</strong> </p>
+  		<p class="sample-count">SAMPLES <strong class="js-test-sampleCount"> {{$ctrl.disease.samples.length}}</strong> </p>
 
   		<p class="sample-positives sample-count--item">
-  			 <span class="material-icons">{{ !$ctrl.isLoading ? 'add_circle_outline' : 'refresh'}}</span> 
-  			 <span ng-if="!$ctrl.isLoading" class="js-test-positives">{{$ctrl.positives}}</span> 
+  			 <span class="material-icons">{{ !$ctrl.disease.isLoading ? 'add_circle_outline' : 'refresh'}}</span> 
+  			 <span ng-if="!$ctrl.disease.isLoading" class="js-test-positives">{{$ctrl.disease.positives}}</span> 
   		</p>
 
   		<p class="sample-negatives sample-count--item"> 
-  			<span class="material-icons">{{ !$ctrl.isLoading ? 'remove_circle_outline' : 'refresh'}}</span> 
-  			<span ng-if="!$ctrl.isLoading" class="js-test-negatives">{{$ctrl.negatives}}</span> 
+  			<span class="material-icons">{{ !$ctrl.disease.isLoading ? 'remove_circle_outline' : 'refresh'}}</span> 
+  			<span ng-if="!$ctrl.disease.isLoading" class="js-test-negatives">{{$ctrl.disease.negatives}}</span> 
   		</p>
   	</summary>
 
   	<button 
         class="material-icons query-overview--control__remove" 
         aria-hidden="true"
-        ng-click="$ctrl.onRemoveParam({id: $ctrl.name, paramRef:'name', paramType:'disease'})"
+        ng-click="$ctrl.onRemoveParam([$ctrl.disease])"
     >close</button>
 
  </div>	  		

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/mutationListing/mutationListing.component.js
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/mutationListing/mutationListing.component.js
@@ -1,28 +1,29 @@
-const template = require('./mutationListing.tpl.html');
+const template = require("./mutationListing.tpl.html");
 
 const mutationListingComponent = {
     template,
-    
+
     bindings: {
-        'symbol':        '<',
-        'entrezgene':    '<',
-        'onRemoveParam': '&'
+        gene: "<",
+        onRemoveParam: "<"
     },
-    controller: ['$rootScope','$log',function($rootScope, $log){
-            'ngInject';
-             
-             const vm = this;
+    controller: [
+        "$rootScope",
+        "$log",
+        function($rootScope, $log) {
+            "ngInject";
 
-             vm.$onInit = ()=>{
-                $log = $log.getInstance('mutationListingComponent', true);
-                $log.log(`${this.symbol}:`);   
-             }
-             
+            const vm = this;
 
-        }]
-}
+            vm.$onInit = () => {
+                $log = $log.getInstance("mutationListingComponent", true);
+                $log.log(`${this.gene.symbol}:`);
+            };
+        }
+    ]
+};
 
 export default {
-	name: 'mutationListing',
-	obj: mutationListingComponent
+    name: "mutationListing",
+    obj: mutationListingComponent
 };

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/mutationListing/mutationListing.tpl.html
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/mutationListing/mutationListing.tpl.html
@@ -1,9 +1,9 @@
 <div class="query-overview--control-param mutation-listing">
-  	<span class="query-overview--control-param-title">{{$ctrl.symbol}}</span>
+  	<span class="query-overview--control-param-title">{{$ctrl.gene.symbol}}</span>
   	<button 
   		class="material-icons query-overview--control__remove" 
   		aria-hidden="true"
-  		ng-click="$ctrl.onRemoveParam({id: $ctrl.entrezgene, paramRef:'entrezgene', paramType:'mutations'})"
+  		ng-click="$ctrl.onRemoveParam([$ctrl.gene])"
   	>
       close 
     </button>

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.component.js
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.component.js
@@ -1,34 +1,34 @@
-const template = require('./queryOverviewControl.tpl.html');
+const template = require("./queryOverviewControl.tpl.html");
 
 const QueryOverviewControlComponent = {
     template,
-    bindings: {   
-    	'title':       '@',
-        'setTitle':    '@',
-        'desc':        '@',
-        'listType':    '@',
-        'paramList':   '<',
-        'removeParam': '&'
+    bindings: {
+        title: "@",
+        setTitle: "@",
+        desc: "@",
+        listType: "@",
+        paramList: "<",
+        removeParam: "<"
     },
-    controller: ['$state','$log',function ($state, $log) {
-        'ngInject';
+    controller: [
+        "$state",
+        "$log",
+        function($state, $log) {
+            "ngInject";
 
-        $log = $log.getInstance('QueryOverviewControlComponent', false);
-        
-        
-        let vm = this;
+            $log = $log.getInstance("QueryOverviewControlComponent", false);
 
-        vm.$onInit = ()=>{
-            $log.log(vm.title);
-            vm.active = $state.current.name.includes(vm.listType);
+            let vm = this;
+
+            vm.$onInit = () => {
+                $log.log(vm.title);
+                vm.active = $state.current.name.includes(vm.listType);
+            };
         }
-
-
-
-    }]
-}
+    ]
+};
 
 export default {
-	name: 'queryOverviewControl',
-	obj: QueryOverviewControlComponent
+    name: "queryOverviewControl",
+    obj: QueryOverviewControlComponent
 };

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.tpl.html
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.tpl.html
@@ -1,17 +1,16 @@
-<div
+<button
   ui-sref="app.queryBuilder.{{$ctrl.listType}}"
-	class="query-overview--control
+	class="query-overview-control
 			   query-overview--{{::$ctrl.title.toLowerCase()}}"
-  ng-class="{'active': $ctrl.active}"
+  ng-class="{'query-overview-control--active': $ctrl.active}"
 >
-  <h4 class="query-overview--control-title">
+  <h4 class="query-overview-control__title">
 		<span class="js-test-title">
-      Add {{::$ctrl.title}} <small class="query-overview--control-count" ng-if="$ctrl.paramList.length">({{$ctrl.paramList.length}})</small>
+      Add {{::$ctrl.title}} <small class="query-overview-control__count" ng-if="$ctrl.paramList.length">({{$ctrl.paramList.length}})</small>
     </span>
   </h4>
-  <div class="row query-overview--control-params">
+  <div class="query-overview-control__params">
   		<mutation-listing
-        class="col-lg-6"
   			ng-if=" $ctrl.listType == 'mutations' "
   			ng-repeat="gene in $ctrl.paramList"
   			symbol="gene.symbol"
@@ -30,4 +29,4 @@
         on-remove-param="$ctrl.removeParam({id, paramRef,paramType})"
   		></disease-listing>
   </div>
-</div>
+</button>

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.tpl.html
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.tpl.html
@@ -13,20 +13,15 @@
   		<mutation-listing
   			ng-if=" $ctrl.listType == 'mutations' "
   			ng-repeat="gene in $ctrl.paramList"
-  			symbol="gene.symbol"
-        entrezgene="gene.entrezgene"
-        on-remove-param="$ctrl.removeParam({id, paramRef,paramType})"
+  			gene="gene"
+        on-remove-param="$ctrl.removeParam"
   		></mutation-listing>
 
   		<disease-listing
   			ng-if="$ctrl.listType == 'disease'"
   			ng-repeat="disease in $ctrl.paramList | orderBy : 'positives' : true "
-  			name="{{::disease.name}}"
-        samples="disease.samples"
-        positives="disease.positives"
-        negatives="disease.negatives"
-        is-loading="disease.mutationsLoading"
-        on-remove-param="$ctrl.removeParam({id, paramRef,paramType})"
+        disease="disease"
+        on-remove-param="$ctrl.removeParam"
   		></disease-listing>
   </div>
 </button>

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
@@ -210,16 +210,6 @@ const QueryParamSelectorComponent = {
       };
 
       /**
-       * @param  {Array} list- array of objects to sort
-       * @param  {String} sortOn - object key to sort on
-       *
-       * @return {Array}
-       */
-      vm.sortResultsBy = (list, sortOn) => {
-        vm.searchResults = sortedResultsBy(list, sortOn);
-      };
-
-      /**
        * Checks to see if add to/remove from query button should be disabled
        */
       vm.isButtonDisabled = () => {
@@ -232,6 +222,10 @@ const QueryParamSelectorComponent = {
         }
       };
 
+      /**
+       * Returns appropriate button title based on active tab
+       * @return {string} - button title
+       */
       vm.getButtonTitle = () => {
         if (
           vm.activeTab === "search" ||
@@ -255,11 +249,18 @@ const QueryParamSelectorComponent = {
         );
       }
 
+      /**
+       * Removes selected params from query and refreshes search results
+       * @param  {Array} selectedParams - selected search params to be removed
+       */
       function _clickedRemoveButton(selectedParams) {
         const addedParams = vm.onParamRemove({ selectedParams });
         getSearchResults(vm.searchQuery);
       }
 
+      /**
+       * Calls the remove/add query functions based on active tab
+       */
       vm.clickedButton = () => {
         const _params =
           vm.activeTab === "search"
@@ -271,21 +272,6 @@ const QueryParamSelectorComponent = {
         } else {
           _clickedRemoveButton(_selectedParams);
         }
-      };
-
-      /**
-       * Sorts an Array in descending order based on teh given key
-       * @param  {Array} list- array of objects to sort
-       * @param  {String} sortOn - object key to sort on
-       *
-       * @return {Array}
-       */
-      let sortedResultsBy = (list, sortOn) => {
-        let results = _.assign([], list);
-        let sortedList = _.sortBy(results, sortOn).reverse(); //reverse it to make it a descending list
-
-        return sortedList;
-        // return (isSorted(results, sortedList, sortOn) ? results.reverse() : sortedList);
       };
     }
   ]

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
@@ -257,10 +257,7 @@ const QueryParamSelectorComponent = {
 
       function _clickedRemoveButton(selectedParams) {
         const addedParams = vm.onParamRemove({ selectedParams });
-        vm.searchResults = _filteredSearchResults(
-          vm.searchResults,
-          addedParams
-        );
+        getSearchResults(vm.searchQuery);
       }
 
       vm.clickedButton = () => {

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
@@ -231,7 +231,7 @@ const QueryParamSelectorComponent = {
        */
       vm.clickedAddButton = results => {
         const _selectedResults = results.filter(result => result.isSelected);
-        vm.onParamSelect({ queryParamData: results });
+        vm.onParamSelect({ selectedParams: _selectedResults });
         vm.searchResults = _filteredSearchResults(results, _selectedResults);
       };
 

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
@@ -4,6 +4,7 @@ const QueryParamSelectorComponent = {
   template,
   bindings: {
     onParamSelect: "&",
+    onParamRemove: "&",
     mutationsSet: "<",
     diseaseSet: "<"
   },
@@ -244,23 +245,34 @@ const QueryParamSelectorComponent = {
 
       /**
        * Adds selected results to query and filters out the newly added params from search results
-       * @param  {Array} results - search results
+       * @param  {Array} selectedParams - selected search params to be added
        */
-      function _clickedAddButton(results) {
-        const _selectedResults = results.filter(result => result.isSelected);
-        vm.onParamSelect({ selectedParams: _selectedResults });
-        vm.searchResults = _filteredSearchResults(results, _selectedResults);
+      function _clickedAddButton(selectedParams) {
+        const addedParams = vm.onParamSelect({ selectedParams });
+        vm.searchResults = _filteredSearchResults(
+          vm.searchResults,
+          addedParams
+        );
       }
 
-      function _clickedRemoveButton(results) {
-        console.log(results);
+      function _clickedRemoveButton(selectedParams) {
+        const addedParams = vm.onParamRemove({ selectedParams });
+        vm.searchResults = _filteredSearchResults(
+          vm.searchResults,
+          addedParams
+        );
       }
 
-      vm.clickedButton = results => {
+      vm.clickedButton = () => {
+        const _params =
+          vm.activeTab === "search"
+            ? vm.searchResults
+            : vm[`${vm.currentState()}Set`];
+        const _selectedParams = _params.filter(param => param.isSelected);
         if (vm.activeTab === "search") {
-          _clickedAddButton(results);
+          _clickedAddButton(_selectedParams);
         } else {
-          _clickedRemoveButton(results);
+          _clickedRemoveButton(_selectedParams);
         }
       };
 

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
@@ -219,20 +219,49 @@ const QueryParamSelectorComponent = {
       };
 
       /**
-       * Checks to see if add to query button should be disabled
+       * Checks to see if add to/remove from query button should be disabled
        */
-      vm.isAddToQueryButtonDisabled = () => {
-        return !vm.searchResults.some(result => result.isSelected);
+      vm.isButtonDisabled = () => {
+        if (vm.activeTab === "search") {
+          return !vm.searchResults.some(result => result.isSelected);
+        } else {
+          return !vm[`${vm.currentState()}Set`].some(
+            result => result.isSelected
+          );
+        }
+      };
+
+      vm.getButtonTitle = () => {
+        if (
+          vm.activeTab === "search" ||
+          !vm[`${vm.currentState()}Set`].length
+        ) {
+          return "Add to query";
+        } else {
+          return "Remove from query";
+        }
       };
 
       /**
        * Adds selected results to query and filters out the newly added params from search results
        * @param  {Array} results - search results
        */
-      vm.clickedAddButton = results => {
+      function _clickedAddButton(results) {
         const _selectedResults = results.filter(result => result.isSelected);
         vm.onParamSelect({ selectedParams: _selectedResults });
         vm.searchResults = _filteredSearchResults(results, _selectedResults);
+      }
+
+      function _clickedRemoveButton(results) {
+        console.log(results);
+      }
+
+      vm.clickedButton = results => {
+        if (vm.activeTab === "search") {
+          _clickedAddButton(results);
+        } else {
+          _clickedRemoveButton(results);
+        }
       };
 
       /**

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
@@ -255,7 +255,6 @@ const QueryParamSelectorComponent = {
        */
       function _clickedRemoveButton(selectedParams) {
         const addedParams = vm.onParamRemove({ selectedParams });
-        getSearchResults(vm.searchQuery);
       }
 
       /**
@@ -273,6 +272,10 @@ const QueryParamSelectorComponent = {
           _clickedRemoveButton(_selectedParams);
         }
       };
+
+      $scope.$on("REMOVED_PARAMS_FROM_QUERY", () => {
+        getSearchResults(vm.searchQuery);
+      });
     }
   ]
 };

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.component.js
@@ -119,12 +119,10 @@ const QueryParamSelectorComponent = {
           .query(searchQuery, vm.mutationsSet)
           .then(response => {
             $scope.$apply(() => {
-              if (response.length) {
-                vm.searchResults = _filteredSearchResults(
-                  response,
-                  vm[`${vm.currentState()}Set`]
-                );
-              }
+              vm.searchResults = _filteredSearchResults(
+                response,
+                vm[`${vm.currentState()}Set`]
+              );
 
               vm.isSearching = false;
             });

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
@@ -42,7 +42,7 @@
 		is-searching="$ctrl.isSearching"
 		is-filter-disabled="$ctrl.currentState() === 'mutations'"
 	></cg-table>
-	<p ng-if="!$ctrl.searchResults.length && $ctrl.currentState() === 'mutations'">Begin searching to see results</p>
+	<p ng-if="!$ctrl.searchResults.length && $ctrl.currentState() === 'mutations' && !$ctrl.isSearching">Begin searching to see results</p>
 </div>
 <div
 	ng-if="$ctrl.activeTab === 'added'"

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
@@ -24,7 +24,7 @@
 		class="tabs__button"
 		ng-click="$ctrl.activeTab = 'search'"
 		ng-class="{'tabs__button--active': $ctrl.activeTab === 'search'}"
-	>Search Results ({{$ctrl.searchResults.length}})</button>
+	>Search Results</button>
 	<button
 		class="tabs__button"
 		ng-click="$ctrl.activeTab = 'added'"

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
@@ -12,7 +12,7 @@
 	<input id="query-param-selector-input"
 		type="text"
 		class="textbox"
-		placeholder="Search {{$ctrl.currentState() === 'mutations' ? 'genes' : 'diseases'}} by name"
+		placeholder="Search {{$ctrl.currentState() === 'mutations' ? 'genes' : 'diseases'}}"
 		ng-change="$ctrl.onInputChange($ctrl.searchQuery)"
 		ng-model="$ctrl.searchQuery"
 		ng-model-options="{debounce: 300}"
@@ -42,7 +42,8 @@
 		is-searching="$ctrl.isSearching"
 		is-filter-disabled="$ctrl.currentState() === 'mutations'"
 	></cg-table>
-	<p ng-if="!$ctrl.searchResults.length && $ctrl.currentState() === 'mutations' && !$ctrl.isSearching">Begin searching to see results</p>
+	<p ng-if="!$ctrl.searchQuery.length && $ctrl.currentState() === 'mutations' && !$ctrl.isSearching">Begin searching to see results.</p>
+	<p ng-if="$ctrl.searchQuery.length && !$ctrl.searchResults.length && $ctrl.currentState() === 'mutations' && !$ctrl.isSearching">No results found.</p>
 </div>
 <div
 	ng-if="$ctrl.activeTab === 'added'"

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
@@ -2,7 +2,7 @@
 	<h2>{{$ctrl.currentState()}} Selector</h2>
 	<button
 		class="button button--secondary"
-		ng-click="$ctrl.clickedButton($ctrl.searchResults)"
+		ng-click="$ctrl.clickedButton()"
 		ng-disabled="$ctrl.isButtonDisabled()"
 	>
 		{{ $ctrl.getButtonTitle()}}

--- a/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
+++ b/app/js/components/queryBuilder/queryParamSelector/queryParamSelector.tpl.html
@@ -2,10 +2,10 @@
 	<h2>{{$ctrl.currentState()}} Selector</h2>
 	<button
 		class="button button--secondary"
-		ng-click="$ctrl.clickedAddButton($ctrl.searchResults)"
-		ng-disabled="$ctrl.isAddToQueryButtonDisabled()"
+		ng-click="$ctrl.clickedButton($ctrl.searchResults)"
+		ng-disabled="$ctrl.isButtonDisabled()"
 	>
-		Add to query
+		{{ $ctrl.getButtonTitle()}}
 	</button>
 </header>
 <div class="query-param-selector__search">

--- a/app/js/on_config.js
+++ b/app/js/on_config.js
@@ -81,7 +81,7 @@ function OnConfig(
                         disease-set="$ctrl.diseaseSet"
                         mutations-set="$ctrl.mutationsSet" 
                         on-change="$ctrl.onInputChange(search)" 
-                        on-param-select="$ctrl.addParamToQuery(queryParamData)"
+                        on-param-select="$ctrl.addParamsToQuery(selectedParams)"
                     />`
         }
       }
@@ -104,7 +104,7 @@ function OnConfig(
                         mutations-set="$ctrl.mutationsSet" 
                         on-change="$ctrl.onInputChange(search)" 
                         search-results="$ctrl.searchResults" 
-                        on-param-select="$ctrl.addParamToQuery(queryParamData)"
+                        on-param-select="$ctrl.addParamsToQuery(selectedParams)"
                     />`
         }
       }

--- a/app/js/on_config.js
+++ b/app/js/on_config.js
@@ -80,8 +80,8 @@ function OnConfig(
           template: `<query-param-selector 
                         disease-set="$ctrl.diseaseSet"
                         mutations-set="$ctrl.mutationsSet" 
-                        on-change="$ctrl.onInputChange(search)" 
                         on-param-select="$ctrl.addParamsToQuery(selectedParams)"
+                        on-param-remove="$ctrl.removeParamFromQuery(selectedParams)"
                     />`
         }
       }
@@ -102,9 +102,8 @@ function OnConfig(
           template: `<query-param-selector 
                         disease-set="$ctrl.diseaseSet"
                         mutations-set="$ctrl.mutationsSet" 
-                        on-change="$ctrl.onInputChange(search)" 
-                        search-results="$ctrl.searchResults" 
                         on-param-select="$ctrl.addParamsToQuery(selectedParams)"
+                        on-param-remove="$ctrl.removeParamFromQuery(selectedParams)"
                     />`
         }
       }

--- a/app/js/on_config.js
+++ b/app/js/on_config.js
@@ -72,7 +72,7 @@ function OnConfig(
           template: `<query-overview 
                         mutations-set="$ctrl.mutationsSet" 
                         disease-set="$ctrl.diseaseSet"
-                        remove-param="$ctrl.removeParamFromQuery({id, paramRef,paramType})"
+                        remove-param="$ctrl.removeParamsFromQuery"
                         user="$ctrl.user"
                     />`
         },
@@ -81,7 +81,7 @@ function OnConfig(
                         disease-set="$ctrl.diseaseSet"
                         mutations-set="$ctrl.mutationsSet" 
                         on-param-select="$ctrl.addParamsToQuery(selectedParams)"
-                        on-param-remove="$ctrl.removeParamFromQuery(selectedParams)"
+                        on-param-remove="$ctrl.removeParamsFromQuery(selectedParams)"
                     />`
         }
       }
@@ -93,8 +93,9 @@ function OnConfig(
       views: {
         queryOverview: {
           template: `<query-overview 
-                        mutations-set="$ctrl.mutationsSet"
+                        mutations-set="$ctrl.mutationsSet" 
                         disease-set="$ctrl.diseaseSet"
+                        remove-param="$ctrl.removeParamsFromQuery"
                         user="$ctrl.user"
                     />`
         },
@@ -103,7 +104,7 @@ function OnConfig(
                         disease-set="$ctrl.diseaseSet"
                         mutations-set="$ctrl.mutationsSet" 
                         on-param-select="$ctrl.addParamsToQuery(selectedParams)"
-                        on-param-remove="$ctrl.removeParamFromQuery(selectedParams)"
+                        on-param-remove="$ctrl.removeParamsFromQuery(selectedParams)"
                     />`
         }
       }

--- a/test/unit/components/queryBuilder/queryBuilder_spec.js
+++ b/test/unit/components/queryBuilder/queryBuilder_spec.js
@@ -38,7 +38,8 @@ describe("UNIT::component: queryBuilder:", () => {
               entrezgene: 4331,
               name: "MNAT1, CDK activating kinase assembly factor",
               symbol: "MNAT1",
-              taxid: 9606
+              taxid: 9606,
+              isSelected: false
             }
           ],
           diseases: [
@@ -47,21 +48,24 @@ describe("UNIT::component: queryBuilder:", () => {
               name: "adrenocortical cancer",
               positives: 20,
               samples: [],
-              mutationsLoading: false
+              mutationsLoading: false,
+              isSelected: false
             },
             {
               acronym: "BLCA",
               name: "bladder urothelial carcinoma",
               positives: 11,
               samples: [],
-              mutationsLoading: false
+              mutationsLoading: false,
+              isSelected: false
             },
             {
               acronym: "CHOL",
               name: "cholangiocarcinoma",
               positives: 33,
               samples: [],
-              mutationsLoading: false
+              mutationsLoading: false,
+              isSelected: false
             }
           ]
         }
@@ -99,60 +103,18 @@ describe("UNIT::component: queryBuilder:", () => {
     })
   );
 
-  it("clearSet: should clear all items from given setType", () => {
-    ctrl.clearSet({ setType: "mutations" });
-    expect(ctrl.mutationsSet.length).toBe(0);
-  });
-
-  it("should sort the specified set by the passed param name", () => {
-    // rearrange the disease order
-
-    bindings.diseaseSet = [
-      parentScope.STATE.query.diseases[1],
-      parentScope.STATE.query.diseases[2],
-      parentScope.STATE.query.diseases[0]
-    ];
-    ctrl = $componentController(
-      "queryBuilder",
-      { scope: parentScope },
-      bindings
-    );
-
-    expect(ctrl.sortSetOn({ sortOn: "acronym", set: "disease" })).toEqual([
-      {
-        acronym: "ACC",
-        name: "adrenocortical cancer",
-        positives: 20,
-        samples: [],
-        mutationsLoading: false
-      },
-      {
-        acronym: "BLCA",
-        name: "bladder urothelial carcinoma",
-        positives: 11,
-        samples: [],
-        mutationsLoading: false
-      },
-      {
-        acronym: "CHOL",
-        name: "cholangiocarcinoma",
-        positives: 33,
-        samples: [],
-        mutationsLoading: false
-      }
-    ]);
-  });
-
   describe("mutationsSet", () => {
     it("should remove a specified param from the set", () => {
       expect(ctrl.mutationsSet).toEqual(parentScope.STATE.query.mutations);
 
       expect(
-        ctrl.removeParamFromQuery({
-          paramType: "mutations",
-          id: 4331,
-          paramRef: "entrezgene"
-        })
+        ctrl.removeParamsFromQuery([
+          {
+            paramType: "mutations",
+            id: 4331,
+            paramRef: "entrezgene"
+          }
+        ])
       ).toEqual([]);
 
       expect(ctrl.mutationsSet.length).toEqual(0);
@@ -168,12 +130,11 @@ describe("UNIT::component: queryBuilder:", () => {
         name: "inhibitor of CDK, cyclin A1 interacting protein 1",
         symbol: "INCA1",
         taxid: 9606,
-        isSelected: true
+        isSelected: false
       };
 
-      expect(ctrl.addParamToQuery([additionalParam])).toEqual([
-        ...parentScope.STATE.query.mutations,
-        additionalParam
+      expect(ctrl.addParamsToQuery([additionalParam])).toEqual([
+        ...parentScope.STATE.query.mutations
       ]);
 
       expect(ctrl.mutationsSet.length).toEqual(2);
@@ -188,25 +149,32 @@ describe("UNIT::component: queryBuilder:", () => {
     it("should remove a specified param from the set", () => {
       expect(ctrl.diseaseSet).toEqual(parentScope.STATE.query.diseases);
       expect(
-        ctrl.removeParamFromQuery({
-          paramType: "disease",
-          id: "BLCA",
-          paramRef: "acronym"
-        })
+        ctrl.removeParamsFromQuery([
+          {
+            acronym: "BLCA",
+            name: "bladder urothelial carcinoma",
+            positives: 11,
+            samples: [],
+            mutationsLoading: false,
+            isSelected: false
+          }
+        ])
       ).toEqual([
         {
           acronym: "ACC",
           name: "adrenocortical cancer",
           positives: 20,
           samples: [],
-          mutationsLoading: false
+          mutationsLoading: false,
+          isSelected: false
         },
         {
           acronym: "CHOL",
           name: "cholangiocarcinoma",
           positives: 33,
           samples: [],
-          mutationsLoading: false
+          mutationsLoading: false,
+          isSelected: false
         }
       ]);
 
@@ -225,9 +193,8 @@ describe("UNIT::component: queryBuilder:", () => {
         isSelected: true
       };
 
-      expect(ctrl.addParamToQuery([additionalParam])).toEqual([
-        ...parentScope.STATE.query.diseases,
-        additionalParam
+      expect(ctrl.addParamsToQuery([additionalParam])).toEqual([
+        ...parentScope.STATE.query.diseases
       ]);
 
       expect(ctrl.diseaseSet.length).toEqual(4);

--- a/test/unit/components/queryBuilder/queryOverview/queryOverviewControl/diseaseListing/diseaseListing_spec.js
+++ b/test/unit/components/queryBuilder/queryOverview/queryOverviewControl/diseaseListing/diseaseListing_spec.js
@@ -38,12 +38,8 @@ describe("UNIT::component: diseaseListing:", () => {
               <disease-listing
                 ng-if="listType == 'disease'"
                 ng-repeat="disease in paramList | orderBy : 'positives' : true "
-                name="{{::disease.name}}"
-                samples="disease.samples"
-                positives="disease.positives"
-                negatives="disease.negatives"
-                is-loading="disease.mutationsLoading"
-                on-remove-param="removeParam({id, paramRef,paramType})"
+                disease=disease
+                on-remove-param="removeParam"
               ></disease-listing>
 
             </div>
@@ -140,10 +136,6 @@ describe("UNIT::component: diseaseListing:", () => {
 
     removeParamButton.triggerHandler("click");
 
-    expect(parentScope.removeParam).toHaveBeenCalledWith({
-      id: "adrenocortical cancer",
-      paramRef: "name",
-      paramType: "disease"
-    });
+    expect(parentScope.removeParam).toHaveBeenCalled();
   });
 });

--- a/test/unit/components/queryBuilder/queryOverview/queryOverviewControl/mutationListing/mutationListing_spec.js
+++ b/test/unit/components/queryBuilder/queryOverview/queryOverviewControl/mutationListing/mutationListing_spec.js
@@ -34,8 +34,7 @@ describe("UNIT::component: mutationListing:", () => {
               <mutation-listing
                 ng-if="listType == 'mutations' "
                 ng-repeat="gene in mutationsList"
-                symbol="gene.symbol"
-                entrezgene="gene.entrezgene"
+                gene=gene
                 on-remove-param="removeParam({id, paramRef,paramType})"
               ></mutation-listing>
             </div>
@@ -97,10 +96,6 @@ describe("UNIT::component: mutationListing:", () => {
     );
     removeParamButton.triggerHandler("click");
 
-    expect(parentScope.removeParam).toHaveBeenCalledWith({
-      id: 4331,
-      paramRef: "entrezgene",
-      paramType: "mutations"
-    });
+    expect(parentScope.removeParam).toHaveBeenCalled();
   });
 });

--- a/test/unit/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl_spec.js
+++ b/test/unit/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl_spec.js
@@ -65,7 +65,7 @@ describe("UNIT::component: queryOverviewControl:", () => {
                 desc="classify samples by their mutation status in selected genes"
                 list-type="mutations"
                 param-list="mutationsList"
-                remove-param="removeParam({id, paramRef, paramType})"
+                remove-param="removeParam"
               >
               </query-overview-control>
               <query-overview-control
@@ -74,7 +74,7 @@ describe("UNIT::component: queryOverviewControl:", () => {
                 desc="Select Samples to Include in Query by Disease Type"
                 list-type="disease"
                 param-list="diseaseList"
-                remove-param="removeParam({id, paramRef, paramType})"
+                remove-param="removeParam"
                 >
               </query-overview-control >
         `);

--- a/test/unit/components/queryBuilder/queryOverview/queryOverview_spec.js
+++ b/test/unit/components/queryBuilder/queryOverview/queryOverview_spec.js
@@ -1,122 +1,120 @@
-describe('UNIT::component: queryOverview:', () => {
- 
+describe("UNIT::component: queryOverview:", () => {
   let parentScope;
-  let element;  
+  let element;
   let $state;
   let mutationListings;
   let diseaseListings;
   var $componentController;
-  
 
   function findIn(element, selector) {
     let el = element[0] ? element[0] : element;
-  	return angular.element(el.querySelector(selector));
-   }
+    return angular.element(el.querySelector(selector));
+  }
 
+  //load templates from $templateCache
+  beforeEach(angular.mock.module("app"));
+  beforeEach(angular.mock.module("app.components"));
+  beforeEach(
+    inject(function(_$componentController_, _$state_) {
+      $componentController = _$componentController_;
+      $state = _$state_;
+    })
+  );
+  beforeEach(
+    inject(($compile, $rootScope) => {
+      parentScope = $rootScope.$new();
 
-   //load templates from $templateCache
-  beforeEach(angular.mock.module('app'));
-  beforeEach(angular.mock.module('app.components'));
-  beforeEach(inject(function(_$componentController_,_$state_) {
-    $componentController = _$componentController_;
-    $state = _$state_;
-  }));
-  beforeEach(inject(($compile, $rootScope) => {
-      
-        parentScope = $rootScope.$new();
+      parentScope.removeParamFromQuery = jasmine.createSpy("removeParam");
 
-        parentScope.removeParamFromQuery = jasmine.createSpy('removeParam');
+      parentScope.mutationList = [
+        {
+          _id: "4331",
+          _score: 17.74919,
+          entrezgene: 4331,
+          name: "MNAT1, CDK activating kinase assembly factor",
+          symbol: "MNAT1",
+          taxid: 9606
+        },
+        {
+          _id: "388324",
+          _score: 15.771275,
+          entrezgene: 388324,
+          name: "inhibitor of CDK, cyclin A1 interacting protein 1",
+          symbol: "INCA1",
+          taxid: 9606
+        },
+        {
+          _id: "1030",
+          _score: 0.9556542,
+          entrezgene: 1030,
+          name: "cyclin dependent kinase inhibitor 2B",
+          symbol: "CDKN2B",
+          taxid: 9606
+        }
+      ];
 
-        parentScope.mutationList =[
-          {
-            '_id': '4331',
-            '_score': 17.74919,
-            'entrezgene': 4331,
-            'name': 'MNAT1, CDK activating kinase assembly factor',
-            'symbol': 'MNAT1',
-            'taxid': 9606
-          },
-          {
-            '_id': '388324',
-            '_score': 15.771275,
-            'entrezgene': 388324,
-            'name': 'inhibitor of CDK, cyclin A1 interacting protein 1',
-            'symbol': 'INCA1',
-            'taxid': 9606
-          },
-          {
-            '_id': '1030',
-            '_score': 0.9556542,
-            'entrezgene': 1030,
-            'name': 'cyclin dependent kinase inhibitor 2B',
-            'symbol': 'CDKN2B',
-            'taxid': 9606
-          }
-        ];
-
-
-        parentScope.diseaseList =[
-          {
-            'acronym': 'ACC',
-            'name': 'adrenocortical cancer',
-            'positives': 20,
-            'samples':[],
-            'mutationsLoading': false
-          },
-          {
-            'acronym': 'BLCA',
-            'name': 'bladder urothelial carcinoma',
-            'positives': 11,
-            'samples':[],
-            'mutationsLoading': false
-          },
-           {
-              'acronym': 'CHOL',
-              'name': 'cholangiocarcinoma',
-              'positives': 33,
-              'samples':[],
-              'mutationsLoading': false
-            }
-      
-        ];
-        element = angular.element(`
+      parentScope.diseaseList = [
+        {
+          acronym: "ACC",
+          name: "adrenocortical cancer",
+          positives: 20,
+          samples: [],
+          mutationsLoading: false
+        },
+        {
+          acronym: "BLCA",
+          name: "bladder urothelial carcinoma",
+          positives: 11,
+          samples: [],
+          mutationsLoading: false
+        },
+        {
+          acronym: "CHOL",
+          name: "cholangiocarcinoma",
+          positives: 33,
+          samples: [],
+          mutationsLoading: false
+        }
+      ];
+      element = angular.element(`
             <query-overview 
               mutations-set='mutationList' 
               disease-set='diseaseList'
-              remove-param="removeParamFromQuery({id, paramRef,paramType})"
+              remove-param="removeParamFromQuery"
             />
         `);
-        $compile(element)(parentScope);      
-        parentScope.$digest();
+      $compile(element)(parentScope);
+      parentScope.$digest();
 
-        mutationListings = angular.element(element[0].querySelectorAll('mutation-listing'));
-        diseaseListings = angular.element(element[0].querySelectorAll('disease-listing'));
+      mutationListings = angular.element(
+        element[0].querySelectorAll("mutation-listing")
+      );
+      diseaseListings = angular.element(
+        element[0].querySelectorAll("disease-listing")
+      );
+    })
+  );
 
- 
-    }));
-    
+  it("renders the proper number of mutationsListing components", () => {
+    expect(mutationListings.length).toEqual(parentScope.mutationList.length);
+  });
 
+  it("renders the proper number of diseaseListing components", () => {
+    expect(diseaseListings.length).toEqual(parentScope.diseaseList.length);
+  });
 
-    it('renders the proper number of mutationsListing components',()=>{
-      expect(mutationListings.length).toEqual(parentScope.mutationList.length);
+  it('should call "removeParamFromQuery" on parent component with given param ', () => {
+    var ctrl = element.isolateScope().$ctrl;
+
+    ctrl.removeParam({
+      id: 388324,
+      paramRef: "entrezgene",
+      paramType: "mutations"
     });
-
-    it('renders the proper number of diseaseListing components',()=>{
-      expect(diseaseListings.length).toEqual(parentScope.diseaseList.length);
+    expect(parentScope.removeParamFromQuery).toHaveBeenCalledWith({
+      id: 388324,
+      paramRef: "entrezgene",
+      paramType: "mutations"
     });
-
-
-    it('should call "removeParamFromQuery" on parent component with given param ',()=>{
-        var ctrl = element.isolateScope().$ctrl;
-
-        ctrl.removeParam({id: 388324, paramRef:'entrezgene', paramType:'mutations'});
-        expect(parentScope.removeParamFromQuery).toHaveBeenCalledWith({id: 388324, paramRef:'entrezgene', paramType:'mutations'}); 
-    });
-
-
-    
-
-
-
-
+  });
 });


### PR DESCRIPTION
## Issue Number
Closes #117 

## Purpose/Implementation Notes
* added the ability to clear all selected added params in the queryParamSelector

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests
* Selecting params from the table in the "Added to Query" tab and clicking the "Remove from Query" removes the appropriate params from the query and repopulates search results
* Clicking the "X" on individual params in the "Overview" sidebar removes the appropriate param from the query and repopulates search results

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots
![pr-137](https://user-images.githubusercontent.com/4724065/36050211-9f98ff2c-0db3-11e8-8e71-1a01287eb63b.gif)

