### PR TITLE
Bugfix/removing wrong param fix

### DIFF
--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -72,10 +72,11 @@ const QueryBuilderComponent = {
        * @return {Array} - return array of added param objects
        */
       vm.removeParamsFromQuery = selectedParams => {
-        const addedParams = selectedParams[0].acronym
-            ? vm["diseaseSet"]
-            : vm["mutationsSet"],
-          comparator = selectedParams[0].acronym ? "acronym" : "_id";
+        const addedParams =
+            selectedParams[0].type === "disease"
+              ? vm["diseaseSet"]
+              : vm["mutationsSet"],
+          comparator = selectedParams[0].type === "disease" ? "acronym" : "_id";
 
         selectedParams.forEach(param => {
           addedParams.splice(

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -75,10 +75,17 @@ const QueryBuilderComponent = {
         const addedParams = selectedParams[0].acronym
             ? vm["diseaseSet"]
             : vm["mutationsSet"],
-          comparator = addedParams === "mutationsSet" ? "_id" : "acronym";
+          comparator = selectedParams[0].acronym ? "acronym" : "_id";
 
         selectedParams.forEach(param => {
-          addedParams.splice(_.indexOf(addedParams, param), 1);
+          addedParams.splice(
+            _.indexOf(
+              addedParams,
+              _.findWhere(addedParams, { [comparator]: param[comparator] })
+            ),
+            1
+          );
+
           $log.log(`removeParamFromQuery: ${param.comparator}`);
         });
 

--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -72,18 +72,13 @@ const QueryBuilderComponent = {
        * @return {Array} - return array of added param objects
        */
       vm.removeParamsFromQuery = selectedParams => {
-        const addedParams = vm[`${vm.currentState()}Set`],
-          comparator = vm.currentState() == "mutations" ? "_id" : "acronym";
+        const addedParams = selectedParams[0].acronym
+            ? vm["diseaseSet"]
+            : vm["mutationsSet"],
+          comparator = addedParams === "mutationsSet" ? "_id" : "acronym";
 
         selectedParams.forEach(param => {
-          addedParams.splice(
-            _.indexOf(
-              addedParams,
-              _.findWhere(addedParams, { [comparator]: param[comparator] })
-            ),
-            1
-          );
-
+          addedParams.splice(_.indexOf(addedParams, param), 1);
           $log.log(`removeParamFromQuery: ${param.comparator}`);
         });
 

--- a/app/js/dataModels/DiseaseModel.js
+++ b/app/js/dataModels/DiseaseModel.js
@@ -16,6 +16,7 @@ function factoryWrapper($log, _, $q, $timeout, $http, AppSettings) {
     this.samples = 0;
     this.negatives = 0;
     this.positives = 0;
+    this.type = "disease";
     return this.build(diseaseResponse, mutationsGenes);
   }
 

--- a/app/js/services/MutationsService.js
+++ b/app/js/services/MutationsService.js
@@ -40,6 +40,9 @@ function MutationsService(
             results.data.total
           }`
         );
+        results.data.hits.forEach(hit => {
+          hit.type = "mutations";
+        });
         resolve(results.data.hits);
       });
     }); // END promise wrapper

--- a/test/unit/components/queryBuilder/queryBuilder_spec.js
+++ b/test/unit/components/queryBuilder/queryBuilder_spec.js
@@ -120,6 +120,23 @@ describe("UNIT::component: queryBuilder:", () => {
       expect(ctrl.mutationsSet.length).toEqual(0);
     });
 
+    it("should remove a specified param from the set regardless of currentState", () => {
+      ctrl.currentState = () => "disease";
+      expect(ctrl.mutationsSet).toEqual(parentScope.STATE.query.mutations);
+
+      expect(
+        ctrl.removeParamsFromQuery([
+          {
+            paramType: "mutations",
+            id: 4331,
+            paramRef: "entrezgene"
+          }
+        ])
+      ).toEqual([]);
+
+      expect(ctrl.mutationsSet.length).toEqual(0);
+    });
+
     it("should add a specified param to the set", () => {
       expect(ctrl.mutationsSet).toEqual(parentScope.STATE.query.mutations);
 
@@ -147,6 +164,42 @@ describe("UNIT::component: queryBuilder:", () => {
     });
 
     it("should remove a specified param from the set", () => {
+      expect(ctrl.diseaseSet).toEqual(parentScope.STATE.query.diseases);
+      expect(
+        ctrl.removeParamsFromQuery([
+          {
+            acronym: "BLCA",
+            name: "bladder urothelial carcinoma",
+            positives: 11,
+            samples: [],
+            mutationsLoading: false,
+            isSelected: false
+          }
+        ])
+      ).toEqual([
+        {
+          acronym: "ACC",
+          name: "adrenocortical cancer",
+          positives: 20,
+          samples: [],
+          mutationsLoading: false,
+          isSelected: false
+        },
+        {
+          acronym: "CHOL",
+          name: "cholangiocarcinoma",
+          positives: 33,
+          samples: [],
+          mutationsLoading: false,
+          isSelected: false
+        }
+      ]);
+
+      expect(ctrl.diseaseSet.length).toEqual(2);
+    });
+
+    it("should remove a specified param from the set regardless of currentState", () => {
+      ctrl.currentState = () => "mutations";
       expect(ctrl.diseaseSet).toEqual(parentScope.STATE.query.diseases);
       expect(
         ctrl.removeParamsFromQuery([

--- a/test/unit/components/queryBuilder/queryBuilder_spec.js
+++ b/test/unit/components/queryBuilder/queryBuilder_spec.js
@@ -39,7 +39,8 @@ describe("UNIT::component: queryBuilder:", () => {
               name: "MNAT1, CDK activating kinase assembly factor",
               symbol: "MNAT1",
               taxid: 9606,
-              isSelected: false
+              isSelected: false,
+              type: "mutations"
             }
           ],
           diseases: [
@@ -49,7 +50,8 @@ describe("UNIT::component: queryBuilder:", () => {
               positives: 20,
               samples: [],
               mutationsLoading: false,
-              isSelected: false
+              isSelected: false,
+              type: "disease"
             },
             {
               acronym: "BLCA",
@@ -57,7 +59,8 @@ describe("UNIT::component: queryBuilder:", () => {
               positives: 11,
               samples: [],
               mutationsLoading: false,
-              isSelected: false
+              isSelected: false,
+              type: "disease"
             },
             {
               acronym: "CHOL",
@@ -65,7 +68,8 @@ describe("UNIT::component: queryBuilder:", () => {
               positives: 33,
               samples: [],
               mutationsLoading: false,
-              isSelected: false
+              isSelected: false,
+              type: "disease"
             }
           ]
         }
@@ -75,11 +79,7 @@ describe("UNIT::component: queryBuilder:", () => {
         mutationsSet: parentScope.STATE.query.mutations,
         diseaseSet: parentScope.STATE.query.diseases,
         currentState: () => "mutations",
-        _updateDiseaseListingsCounts: () => {},
-        progressBar: {
-          advance: () => {},
-          goTo: () => {}
-        }
+        _updateDiseaseListingsCounts: () => {}
       };
 
       ctrl = $componentController(
@@ -173,7 +173,8 @@ describe("UNIT::component: queryBuilder:", () => {
             positives: 11,
             samples: [],
             mutationsLoading: false,
-            isSelected: false
+            isSelected: false,
+            type: "disease"
           }
         ])
       ).toEqual([
@@ -183,7 +184,8 @@ describe("UNIT::component: queryBuilder:", () => {
           positives: 20,
           samples: [],
           mutationsLoading: false,
-          isSelected: false
+          isSelected: false,
+          type: "disease"
         },
         {
           acronym: "CHOL",
@@ -191,7 +193,8 @@ describe("UNIT::component: queryBuilder:", () => {
           positives: 33,
           samples: [],
           mutationsLoading: false,
-          isSelected: false
+          isSelected: false,
+          type: "disease"
         }
       ]);
 
@@ -209,7 +212,8 @@ describe("UNIT::component: queryBuilder:", () => {
             positives: 11,
             samples: [],
             mutationsLoading: false,
-            isSelected: false
+            isSelected: false,
+            type: "disease"
           }
         ])
       ).toEqual([
@@ -219,7 +223,8 @@ describe("UNIT::component: queryBuilder:", () => {
           positives: 20,
           samples: [],
           mutationsLoading: false,
-          isSelected: false
+          isSelected: false,
+          type: "disease"
         },
         {
           acronym: "CHOL",
@@ -227,7 +232,8 @@ describe("UNIT::component: queryBuilder:", () => {
           positives: 33,
           samples: [],
           mutationsLoading: false,
-          isSelected: false
+          isSelected: false,
+          type: "disease"
         }
       ]);
 

--- a/test/unit/components/queryBuilder/queryBuilder_spec.js
+++ b/test/unit/components/queryBuilder/queryBuilder_spec.js
@@ -120,7 +120,7 @@ describe("UNIT::component: queryBuilder:", () => {
       expect(ctrl.mutationsSet.length).toEqual(0);
     });
 
-    it("should remove a specified param from the set regardless of currentState", () => {
+    it("should remove a mutations param from the set while the currentState is 'disease'", () => {
       ctrl.currentState = () => "disease";
       expect(ctrl.mutationsSet).toEqual(parentScope.STATE.query.mutations);
 


### PR DESCRIPTION
## Issue Number
#147 

## Purpose/Implementation Notes
Removing a param on the non-active tab does not delete from the currently active tab params

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests
* Removing a param on the non-active tab in sidebar does not delete from the currently active tab params
* Removing a param on the active tab deletes the appropriate param
* Mass removing params via checkboxes removes the selected params

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
