### PR TITLE
disable button while calculating and show main loading indicator

### DIFF
--- a/app/js/components/queryBuilder/queryBuilder.component.js
+++ b/app/js/components/queryBuilder/queryBuilder.component.js
@@ -72,10 +72,9 @@ const QueryBuilderComponent = {
        * @return {Array} - return array of added param objects
        */
       vm.removeParamsFromQuery = selectedParams => {
-        const addedParams = selectedParams[0].acronym
-            ? vm["diseaseSet"]
-            : vm["mutationsSet"],
-          comparator = selectedParams[0].acronym ? "acronym" : "_id";
+        const paramType = selectedParams[0].acronym ? "disease" : "mutations",
+          addedParams = vm[`${paramType}Set`],
+          comparator = paramType === "disease" ? "acronym" : "_id";
 
         selectedParams.forEach(param => {
           addedParams.splice(
@@ -89,7 +88,7 @@ const QueryBuilderComponent = {
           $log.log(`removeParamFromQuery: ${param.comparator}`);
         });
 
-        vm._updateDiseaseListingsCounts();
+        if (paramType === "mutations") vm._updateDiseaseListingsCounts();
 
         $scope.$broadcast("REMOVED_PARAMS_FROM_QUERY");
 

--- a/app/js/components/queryBuilder/queryOverview/queryOverview.component.js
+++ b/app/js/components/queryBuilder/queryOverview/queryOverview.component.js
@@ -35,6 +35,10 @@ const QueryOverviewComponent = {
         return numberPositives >= 20 && numberNegatives >= 20;
       }
 
+      vm.areSamplesLoading = () => {
+        return vm.diseaseSet.some(disease => disease.isLoading === true);
+      };
+
       vm.clickedSubmitQuery = evt => {
         evt.preventDefault();
         if (_validateClassifier()) {

--- a/app/js/components/queryBuilder/queryOverview/queryOverview.tpl.html
+++ b/app/js/components/queryBuilder/queryOverview/queryOverview.tpl.html
@@ -2,7 +2,7 @@
   <h2>Query Overview</h2>
   <button
     class="button"
-    ng-disabled="!$ctrl.mutationsSet.length || !$ctrl.diseaseSet.length"
+    ng-disabled="$ctrl.areSamplesLoading() || !$ctrl.mutationsSet.length || !$ctrl.diseaseSet.length"
     ng-click="$ctrl.clickedSubmitQuery($event)"
   >
     Submit Query
@@ -25,6 +25,7 @@
   list-type="disease"
   param-list="$ctrl.diseaseSet"
   remove-param="$ctrl.removeParam"
+  is-calculating="$ctrl.areSamplesLoading"
   >
 </query-overview-control >
 <query-modal

--- a/app/js/components/queryBuilder/queryOverview/queryOverview.tpl.html
+++ b/app/js/components/queryBuilder/queryOverview/queryOverview.tpl.html
@@ -1,7 +1,7 @@
 <div class="query-overview__header">
   <h2>Query Overview</h2>
   <button
-    class="button"
+    class="button js-submit-button"
     ng-disabled="$ctrl.areSamplesLoading() || !$ctrl.mutationsSet.length || !$ctrl.diseaseSet.length"
     ng-click="$ctrl.clickedSubmitQuery($event)"
   >

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/_queryOverviewControl.scss
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/_queryOverviewControl.scss
@@ -49,6 +49,18 @@
     color: $white;
   }
 
+  &__loading {
+    position: relative;
+    top: 3px;
+    display: none;
+    font-size: inherit;
+    animation: rotating 1s infinite linear;
+
+    &--active {
+      display: inline-block;
+    }
+  }
+
   &__params {
     margin-top: 15px;
 

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.component.js
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.component.js
@@ -4,8 +4,6 @@ const QueryOverviewControlComponent = {
     template,
     bindings: {
         title: "@",
-        setTitle: "@",
-        desc: "@",
         listType: "@",
         paramList: "<",
         removeParam: "<",

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.component.js
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.component.js
@@ -8,7 +8,8 @@ const QueryOverviewControlComponent = {
         desc: "@",
         listType: "@",
         paramList: "<",
-        removeParam: "<"
+        removeParam: "<",
+        isCalculating: "<"
     },
     controller: [
         "$state",

--- a/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.tpl.html
+++ b/app/js/components/queryBuilder/queryOverview/queryOverviewControl/queryOverviewControl.tpl.html
@@ -6,8 +6,12 @@
 >
   <h4 class="query-overview-control__title">
 		<span class="js-test-title">
-      {{::$ctrl.title}} <span class="query-overview-control__count" ng-if="$ctrl.paramList.length">({{$ctrl.paramList.length}})</span>
+      {{::$ctrl.title}} <span class="query-overview-control__count" ng-if="$ctrl.paramList.length && !$ctrl.isCalculating()">({{$ctrl.paramList.length}})</span>
     </span>
+    <span
+      class="material-icons query-overview-control__loading"
+      ng-class="{'query-overview-control__loading--active': $ctrl.isCalculating() && $ctrl.paramList.length}"
+    >refresh</span>
   </h4>
   <span
     class="query-overview-control__subhead"
@@ -16,18 +20,18 @@
     Click here to begin adding {{::$ctrl.title | lowercase}}
   </span>
   <div class="query-overview-control__params query-overview-control__params--{{::$ctrl.title.toLowerCase()}}">
-  		<mutation-listing
-  			ng-if=" $ctrl.listType == 'mutations' "
-  			ng-repeat="gene in $ctrl.paramList | orderBy : 'name' : false"
-  			gene="gene"
-        on-remove-param="$ctrl.removeParam"
-  		></mutation-listing>
+		<mutation-listing
+			ng-if=" $ctrl.listType == 'mutations' "
+			ng-repeat="gene in $ctrl.paramList | orderBy : 'name' : false"
+			gene="gene"
+      on-remove-param="$ctrl.removeParam"
+		></mutation-listing>
 
-  		<disease-listing
-  			ng-if="$ctrl.listType == 'disease'"
-  			ng-repeat="disease in $ctrl.paramList | orderBy : 'name' : false "
-        disease="disease"
-        on-remove-param="$ctrl.removeParam"
-  		></disease-listing>
-  </div>
+		<disease-listing
+			ng-if="$ctrl.listType == 'disease'"
+			ng-repeat="disease in $ctrl.paramList | orderBy : 'name' : false "
+      disease="disease"
+      on-remove-param="$ctrl.removeParam"
+		></disease-listing>
+</div>
 </button>

--- a/test/unit/components/queryBuilder/queryBuilder_spec.js
+++ b/test/unit/components/queryBuilder/queryBuilder_spec.js
@@ -112,7 +112,8 @@ describe("UNIT::component: queryBuilder:", () => {
           {
             paramType: "mutations",
             id: 4331,
-            paramRef: "entrezgene"
+            paramRef: "entrezgene",
+            type: "mutations"
           }
         ])
       ).toEqual([]);
@@ -129,7 +130,8 @@ describe("UNIT::component: queryBuilder:", () => {
           {
             paramType: "mutations",
             id: 4331,
-            paramRef: "entrezgene"
+            paramRef: "entrezgene",
+            type: "mutations"
           }
         ])
       ).toEqual([]);

--- a/test/unit/components/queryBuilder/queryOverview/queryOverview_spec.js
+++ b/test/unit/components/queryBuilder/queryOverview/queryOverview_spec.js
@@ -1,11 +1,12 @@
 describe("UNIT::component: queryOverview:", () => {
-  let parentScope;
-  let element;
-  let $state;
-  let mutationListings;
-  let diseaseListings;
-  let $componentController;
-  let $httpBackend;
+  let parentScope,
+    element,
+    $state,
+    mutationListings,
+    diseaseListings,
+    $componentController,
+    $httpBackend,
+    ctrl;
 
   function findIn(element, selector) {
     let el = element[0] ? element[0] : element;
@@ -63,21 +64,21 @@ describe("UNIT::component: queryOverview:", () => {
           name: "adrenocortical cancer",
           positives: 20,
           samples: [],
-          mutationsLoading: false
+          isLoading: false
         },
         {
           acronym: "BLCA",
           name: "bladder urothelial carcinoma",
           positives: 11,
           samples: [],
-          mutationsLoading: false
+          isLoading: false
         },
         {
           acronym: "CHOL",
           name: "cholangiocarcinoma",
           positives: 33,
           samples: [],
-          mutationsLoading: false
+          isLoading: false
         }
       ];
       element = angular.element(`
@@ -88,6 +89,8 @@ describe("UNIT::component: queryOverview:", () => {
             />
         `);
       $compile(element)(parentScope);
+
+      ctrl = element.isolateScope().$ctrl;
       parentScope.$digest();
 
       mutationListings = angular.element(
@@ -108,8 +111,6 @@ describe("UNIT::component: queryOverview:", () => {
   });
 
   it('should call "removeParamFromQuery" on parent component with given param ', () => {
-    var ctrl = element.isolateScope().$ctrl;
-
     ctrl.removeParam({
       id: 388324,
       paramRef: "entrezgene",
@@ -120,5 +121,10 @@ describe("UNIT::component: queryOverview:", () => {
       paramRef: "entrezgene",
       paramType: "mutations"
     });
+  });
+
+  it("submit query button should be disabled if diseases are still loading mutation calculations", () => {
+    ctrl.diseaseSet[0].isLoading = true;
+    expect(ctrl.areSamplesLoading()).toBe(true);
   });
 });


### PR DESCRIPTION
## Issue Number
#152 

## Purpose/Implementation Notes
* Submit query button is now disabled until the sample calculations are completed for all disease listings
* show a main disease type tab loading indicator
* add tests for this bug

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests
* while sample calculations are underway, the submit query button is disabled
* when calculations are complete (and both mutations and disease types have been added to query), the submit query button is enabled

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
