### PR TITLE
change mutation service to use an angular promise so scope will be applied

### DIFF
--- a/app/js/services/MutationsService.js
+++ b/app/js/services/MutationsService.js
@@ -32,7 +32,7 @@ function MutationsService(
 
     // promise wrapper
     // @todo: handle reject condition
-    return new Promise(resolve => {
+    return $q(resolve => {
       // get all genes and transform then into Gene Models
       return $http.get(endpoint(geneQuery)).then(results => {
         $log.log(


### PR DESCRIPTION
## Issue Number
Closes #162 

## Purpose/Implementation Notes
Apparently, the mutation service was using a JS promise instead of using `$q` to create a promise. Therefore scope was not being applied/updated to set `isSearching` to `false` even though search results had been returned.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests
* UI doesn't get stuck searching after results have already been returned
